### PR TITLE
Clone options object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ var rImages = /url(?:\(['|"]?)(.*?)(?:['|"]?\))(?!.*\/\*base64:skip\*\/)/ig;
 
 function gulpCssBase64(opts) {
 
-    opts = opts || {};
+    opts = JSON.parse(JSON.stringify(opts || {}));
     opts.maxWeightResource = opts.maxWeightResource || 32768;
     if (util.isArray(opts.extensionsAllowed)) {
         opts.extensionsAllowed = opts.extensionsAllowed;

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,15 @@ describe('gulp-css-base64', function () {
 
     // define here beforeEach(), afterEach()
 
+    it('should not modify original options object', function () {
+        var opts = {
+            foo: 'bar'
+        };
+
+        base64(opts);
+        assert.equal(opts.maxWeightResource, undefined);
+    });
+
     describe('in buffer mode', function () {
         it('should convert url() content', function (done) {
             // create the fake file


### PR DESCRIPTION
Instead of modifying directly the options object, it'll now be "cloned" by using a simple JSON serialization/deserialization.

I made this because I'm using [node-config](https://github.com/lorenwest/node-config) which does return unmodifiable configuration objects, and I saw [this pattern](https://github.com/plus3network/gulp-less/blob/cc0e7426575abbb8fc58843a9cb868fae09ba536/index.js#L13-L16) [in other Gulp plugins](https://github.com/phated/gulp-jade/blob/ebab721ddefe6a66acfa0b8b1598b699fa7e40c7/index.js#L11) as well.