### PR TITLE
Fixes URLs with query strings and hashes in them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,8 @@ function gulpCssBase64(opts) {
                     return;
                   }
 
-                  if (opts.extensionsAllowed.length !== 0 && opts.extensionsAllowed.indexOf(path.extname(result[1])) === -1) {
+                  var pureUrl = result[1].split('?')[0].split('#')[0];
+                  if (opts.extensionsAllowed.length !== 0 && opts.extensionsAllowed.indexOf(path.extname(pureUrl)) === -1) {
                     log('Ignores ' + chalk.yellow(result[1]) + ', extension not allowed ' + chalk.yellow(path.extname(result[1])), opts.verbose);
                     callback();
                     return;

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,31 @@ describe('gulp-css-base64', function () {
       });
     });
 
+    it('should convert url() content with questionmark at end even if extensionsAllowed is passed', function (done) {
+            // create the fake file
+      var fakeFile = new gutil.File({
+        contents: new Buffer('.button_alert{background:url(\'test/fixtures/image/very-very-small.png?awesomeQuestionmark\') no-repeat 4px 5px;padding-left:12px;font-size:12px;color:#888;text-decoration:underline}')
+      });
+
+            // Create a css-base64 plugin stream
+      var stream = base64({
+        extensionsAllowed: ['.gif', '.jpg', '.png']
+      });
+
+            // write the fake file to it
+      stream.write(fakeFile);
+
+            // wait for the file to come back out
+      stream.once('data', function (file) {
+                // make sure it came out the same way it went in
+        assert(file.isBuffer());
+
+                // check the contents
+        assert.equal(file.contents.toString('utf8'), '.button_alert{background:url(\'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANAQAAAABakNnRAAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAAAEgAAABIAEbJaz4AAAArSURBVAjXY/j/g2H/C4b5Jxj6OxgaOEBoxgmGDg8GIACyuRoYjkowfKgAACBpDLQ2kvRRAAAAAElFTkSuQmCC\') no-repeat 4px 5px;padding-left:12px;font-size:12px;color:#888;text-decoration:underline}');
+        done();
+      });
+    });
+
     it('should convert url() content with hashtag at end', function (done) {
             // create the fake file
       var fakeFile = new gutil.File({
@@ -123,6 +148,31 @@ describe('gulp-css-base64', function () {
 
             // Create a css-base64 plugin stream
       var stream = base64();
+
+            // write the fake file to it
+      stream.write(fakeFile);
+
+            // wait for the file to come back out
+      stream.once('data', function (file) {
+                // make sure it came out the same way it went in
+        assert(file.isBuffer());
+
+                // check the contents
+        assert.equal(file.contents.toString('utf8'), '.button_alert{background:url(\'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANAQAAAABakNnRAAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAAAEgAAABIAEbJaz4AAAArSURBVAjXY/j/g2H/C4b5Jxj6OxgaOEBoxgmGDg8GIACyuRoYjkowfKgAACBpDLQ2kvRRAAAAAElFTkSuQmCC\') no-repeat 4px 5px;padding-left:12px;font-size:12px;color:#888;text-decoration:underline}');
+        done();
+      });
+    });
+
+    it('should convert url() content with hashtag at end even if extensionsAllowed is passed', function (done) {
+            // create the fake file
+      var fakeFile = new gutil.File({
+        contents: new Buffer('.button_alert{background:url(\'test/fixtures/image/very-very-small.png#awesomeHashtag\') no-repeat 4px 5px;padding-left:12px;font-size:12px;color:#888;text-decoration:underline}')
+      });
+
+            // Create a css-base64 plugin stream
+      var stream = base64({
+        extensionsAllowed: ['.gif', '.jpg', '.png']
+      });
 
             // write the fake file to it
       stream.write(fakeFile);


### PR DESCRIPTION
The previous fix did not test a corner case where
the user passes extensions allowed in the options.
When there are no options passed for extensions
allowed the extension check is skipped and thus the
file is processed appropriately.

I added virtual copies of the tests so feel free to
point me to a better way of doing that. I just don't
know what a better way to do it is without overwriting
the original tests.

The fix I made was stripping query strings and hashes
from the regex results before the extension check and
then passing in that stripped version into the check
instead of the actual result which has the hash and/or
query string.