### PR TITLE
limit is unnecessary; plus, servers are capable of compressing resour…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ var rImages = /url(?:\(['|"]?)(.*?)(?:['|"]?\))(?!.*\/\*base64:skip\*\/)/ig;
 
 function gulpCssBase64(opts) {
   opts = JSON.parse(JSON.stringify(opts || {}));
-  opts.maxWeightResource = opts.maxWeightResource || 32768;
   if (!util.isArray(opts.extensionsAllowed)) {
     opts.extensionsAllowed = [];
   }
@@ -68,7 +67,7 @@ function gulpCssBase64(opts) {
 
           encodeResource(result[1], file, opts, function (fileRes) {
             if (undefined !== fileRes) {
-              if (fileRes.contents.length > opts.maxWeightResource) {
+              if (opts.maxWeightResource && fileRes.contents.length > opts.maxWeightResource) {
                 log('Ignores ' + chalk.yellow(result[1]) + ', file is too big ' + chalk.yellow(fileRes.contents.length + ' bytes'), opts.verbose);
                 callback();
                 return;


### PR DESCRIPTION
…ces;

otherwise, 32768 should be increased at least to 500KB — some fonts are far beyond 200 KB in size;
one more reason for deleting the Default Limit — the code doesn't throw exception — you only get message in console logs and it's easy to overlook the details in output — which means Important Data can be ignored by the script and this leads to errors in production;